### PR TITLE
Fix for somestyles scenario

### DIFF
--- a/brewdb.ado
+++ b/brewdb.ado
@@ -16,13 +16,13 @@
 *     r(paletteName[#Max][#C]_colorblind) - Colorblindness friendliness		   *
 *                                                                              *
 * Lines -                                                                      *
-*     428                                                                      *
+*     432                                                                      *
 *                                                                              *
 ********************************************************************************
 		
 *! brewdb
-*! v 0.0.1
-*! 08SEP2015
+*! v 0.0.2
+*! 12OCT2015
 
 // Drop the program from memory if loaded
 cap prog drop brewdb
@@ -231,6 +231,15 @@ prog def brewdb
 			
 			// Rename the generic variable 
 			qui: rename v rgb
+			
+			/* This patches a bug with parsing the JavaScript when the array 
+			contains > 10 elements.  This only affected the paired and set3 
+			colorbrewer palettesand trims the extra character added to the 
+			start and/or end of the string. */
+			qui: replace rgb = cond(regexm(rgb, "([0-9][0-9][0-9][0-9]$)"),  ///   
+								substr(rgb, 1, 11), 						 ///   
+						  cond(regexm(rgb, "(^[0-9][0-9][0-9][0-9])"), 		 ///   
+						  substr(rgb, 2, 12), rgb))
 			
 			// Make all palette names lower cased
 			qui: replace palette = lower(palette)

--- a/brewscheme.ado
+++ b/brewscheme.ado
@@ -17,13 +17,13 @@
 *     scheme-`schemename'.scheme                                               *
 *                                                                              *
 * Lines -                                                                      *
-*     1962                                                                     *
+*     1964                                                                     *
 *                                                                              *
 ********************************************************************************
 		
 *! brewscheme
-*! v 0.0.5
-*! 24SEP2015
+*! v 0.0.7
+*! 13OCT2015
 
 // Drop the program from memory if loaded
 cap prog drop brewscheme
@@ -67,9 +67,7 @@ prog def brewscheme, rclass
 				qui: brewdb, `refresh'
 				
 				// Load the lookup table
-				qui: use `"`c(sysdir_personal)'b/brewmeta.dta"', clear
-				
-				
+				qui: use `"`c(sysdir_personal)'b/brewmeta.dta"', clear			
 				
 			} // End IF Block to build look up data set
 				
@@ -79,8 +77,6 @@ prog def brewscheme, rclass
 				// Load the lookup table
 				qui: use `"`c(sysdir_personal)'b/brewmeta.dta"', clear
 
-				char li
-				
 			} // End ELSE Block to load brewmeta file
 			
 			// Get acceptable palette names
@@ -197,7 +193,7 @@ prog def brewscheme, rclass
 				"`matstyle'" == "" | "`reflstyle'" == "" |  		    	 ///   
 				"`refmstyle'" == "" | "`constyle'" == "") & "`somestyle'" != "" {
 				
-				// Check to see if all style was an available palette
+				// Check to see if some style was an available palette
 				if `: list somestyle in palettes' != 1 {
 												
 					// Let user know valid values
@@ -209,7 +205,7 @@ prog def brewscheme, rclass
 				} // End IF Block to check for valid color palette
 				
 				// Loop over # available colors per graph
-				foreach stile in "`grstyles'" {
+				foreach stile in `grstyles' {
 				
 					// If the style is missing and valid # colors for default
 					if "``stile'style'" == "" & `somecolors' <= ``somestyle'c' {
@@ -226,6 +222,7 @@ prog def brewscheme, rclass
 								loc `x'colors `somecolors'
 								loc `x'saturation `somesaturation'
 								
+								
 							} // End IF Block for unspecified graphs
 							
 							// If the graph type has a style specified
@@ -238,6 +235,8 @@ prog def brewscheme, rclass
 							
 						} // End Loop over graph types
 						
+						exit
+						
 					} // End IF Block checking # colors available for default
 					
 					// If more colors specified for default than available
@@ -248,7 +247,7 @@ prog def brewscheme, rclass
 						`"available (``stile'style') in the palette "`stile'style""'
 						
 						// Kill the program
-						exit
+						err 198
 						
 					} // End ELSEIF Block for # colors > available for defaults
 					
@@ -261,7 +260,7 @@ prog def brewscheme, rclass
 						`"available (``stile'style') in the palette "`stile'style""'
 						
 						// Kill the program
-						exit
+						err 198
 						
 					} // End ELSEIF Block for # colors > available for graph types
 					
@@ -719,16 +718,15 @@ prog def brewscheme, rclass
 				} // End ELSE Block for some other values of saturation
 				
 			} // End IF Block for somesaturation value validation
-			
 
 			// Line saturation gets defined as a color multiplier
-			loc linesaturation = `linesaturation'/100
+			// loc linesaturation = `linesaturation'/100
 			
 			// Dot plot saturation is defined as a color multiplier
-			loc dotsaturation = `dotsaturation'/100
+			// loc dotsaturation = `dotsaturation'/100
 								
 			// Scatterplot saturation gets defined as a color multiplier
-			loc scatsaturation = `scatsaturation'/100
+			// loc scatsaturation = `scatsaturation'/100
 					
 			// Write the scheme file to a location on the path
 			qui: file open scheme using ///
@@ -743,7 +741,7 @@ prog def brewscheme, rclass
 			
 			// Loop over color macros
 			foreach color in bar scat area line box dot pie hist ci mat		 ///   
-			refl refm {
+			refl refm sun {
 			
 				/* Create the sequence of color ids for each graph type based on 
 				the maximum number of colors in any listed color argument. */
@@ -756,6 +754,14 @@ prog def brewscheme, rclass
 				qui: levelsof rgb if palette == "``color'style'" & 			 ///   
 				pcolor == ``color'colors', loc(rgbs)
 				
+				if "`dbug'" != "" {
+					levelsof rgb if palette == "``color'style'" & pcolor == ``color'colors'
+					di "Graph type = `color'"
+					// Print debugging message
+					di "Color: `color'" _n "Number of colors: ``color''" _n  ///   
+					`"Color sequence: ``color'seq'"'
+				}
+				
 				// Loop over the rgb values to construct the graph specific  
 				// rgb values
 				foreach c of loc `color'seq {
@@ -767,11 +773,7 @@ prog def brewscheme, rclass
 				
 				// Check for debug option
 				if "`dbug'" != "" {
-				
-					// Print debugging message
-					di "Color: `color'" _n "Number of colors: ``color''" _n  ///   
-					`"Color sequence: ``color'seq'"'
-					
+									
 					// Print the RGB color string to screen
 					di `"``color'rgb'"'
 				
@@ -963,23 +965,23 @@ prog def brewscheme, rclass
 			file write scheme `"color minortick black"' _n
 			file write scheme `"color ci_line black"' _n
 			file write scheme `"color ci_arealine black"' _n
-			file write scheme `"color ci_area "`: char _dta[`cistyle'1]'" "' _n
-			file write scheme `"color ci_symbol "`: char _dta[`cistyle'1]'" "' _n
+			file write scheme `"color ci_area "`: word 1 of `areargb''" "' _n
+			file write scheme `"color ci_symbol "`: word 1 of `cirgb''" "' _n
 			file write scheme `"color ci2_line black"' _n
 			file write scheme `"color ci2_arealine black"' _n
-			file write scheme `"color ci2_area "`: char _dta[`cistyle'2]'" "' _n
-			file write scheme `"color ci2_symbol "`: char _dta[`cistyle'2]'" "' _n
+			file write scheme `"color ci2_area "`: word 2 of `areargb''" "' _n
+			file write scheme `"color ci2_symbol "`: word 2 of `cirgb''" "' _n
 			file write scheme `"color pieline black"' _n
 			file write scheme `"color matrix white"' _n
 			file write scheme `"color matrixmarkline black"' _n
 			file write scheme `"color refmarker black"' _n
 			file write scheme `"color refmarkline black"' _n
-			file write scheme `"color histogram "`: char _dta[`histstyle'1]'" "' _n
+			file write scheme `"color histogram "`: word 1 of `histrgb''" "' _n
 			file write scheme `"color histback white"' _n
 			file write scheme `"color histogram_line black"' _n
 			file write scheme `"color dot_line black"' _n
 			file write scheme `"color dot_arealine black"' _n
-			file write scheme `"color dot_area "`: char _dta[`dotstyle'1]'" "' _n
+			file write scheme `"color dot_area "`: word 1 of `areargb''" "' _n
 			file write scheme `"color dotmarkline black"' _n
 			file write scheme `"color xyline black"' _n
 			file write scheme `"color refline black"' _n
@@ -1006,11 +1008,11 @@ prog def brewscheme, rclass
 			file write scheme `"color contour_begin `constart'"' _n
 			file write scheme `"color contour_end `conend'"' _n
 			file write scheme `"color zyx2 black"' _n
-			file write scheme `"color sunflower "`: char _dta[`sunstyle'1]'""' _n
+			file write scheme `"color sunflower "`: word 1 of `sunrgb''""' _n
 			file write scheme `"color sunflowerlb black"' _n
-			file write scheme `"color sunflowerlf "`: char _dta[`sunstyle'1]'""' _n
+			file write scheme `"color sunflowerlf "`: word 2 of `sunrgb''""' _n
 			file write scheme `"color sunflowerdb black"' _n
-			file write scheme `"color sunflowerdf "`: char _dta[`sunstyle'2]'""' _n
+			file write scheme `"color sunflowerdf "`: word 3 of `sunrgb''""' _n
 			file write scheme `"color pboxlabelfill white"' _n
 			file write scheme `"color plabelfill white"' _n
 			file write scheme `"color pmarkback white"' _n

--- a/brewscheme.pkg
+++ b/brewscheme.pkg
@@ -15,7 +15,7 @@ d KW: Color
 d
 d Requires: Stata version 13.1
 d
-d Distribution-Date: 20150924
+d Distribution-Date: 20151013
 d
 d Author: Billy Buchanan 
 d		  Data Scientist


### PR DESCRIPTION
Fixed bug that caused program to fail writing options when the somestyle parameter was used:

```
brewscheme, scheme(test) barst(set1) barc(6) somest(dark2) somec(6)
```

Would cause RGB values for all graph types but bar graphs to be written to the scheme file.  This is corrected now.

Removed all references to the metadata (characteristics) in brewscheme to lookup the RGB values based on the dataset built by brewdb.ado.  Instead of looking up values with:

```
char _dta[`palette'`colorid']
```

There is now a loop that constructs a local macro for each graph type based on the recycled vector of color IDs and their corresponding RGB values.
