### PR TITLE
Fixes issue with the PERSONAL directory not existing when installing the program

### DIFF
--- a/brewcolordb.ado
+++ b/brewcolordb.ado
@@ -8,13 +8,13 @@
 * Program Output -                                                             *
 *                                                                              *
 * Lines -                                                                      *
-*     333                                                                      *
+*     339                                                                      *
 *                                                                              *
 ********************************************************************************
 		
 *! brewcolordb
 *! v 1.0.2
-*! 12APR2016
+*! 15APR2016
 
 // Drop the program from memory if loaded
 cap prog drop brewcolordb
@@ -46,11 +46,14 @@ prog def brewcolordb, rclass
 	// Store personal directory
 	loc personal `"`c(sysdir_personal)'"'
 	
+	// Check to see if the personal ADOPATH directory exists
+	cap confirm file `"`personal'"'
+	
+	// If it does not exist create the directory
+	if _rc != 0 mkdir `"`personal'"'
+	
 	// Set the rebuild parameter conditional on the replace argument
 	if `"`replace'"' != "" loc rebuild rebuild
-	
-	// Or make the local null
-	else loc rebuild
 	
 	// Remove tilde and replace with HOME environmental variable for color db subdirectory
 	qui: dirfile, p(`"`: subinstr loc personal `"~"' `"`:environment HOME'"', all'brewcolors"') `rebuild'

--- a/brewcolordb.ado
+++ b/brewcolordb.ado
@@ -8,13 +8,13 @@
 * Program Output -                                                             *
 *                                                                              *
 * Lines -                                                                      *
-*     327                                                                      *
+*     333                                                                      *
 *                                                                              *
 ********************************************************************************
 		
 *! brewcolordb
-*! v 1.0.1
-*! 03APR2016
+*! v 1.0.2
+*! 12APR2016
 
 // Drop the program from memory if loaded
 cap prog drop brewcolordb
@@ -46,11 +46,17 @@ prog def brewcolordb, rclass
 	// Store personal directory
 	loc personal `"`c(sysdir_personal)'"'
 	
-	// Remove tilde and replace with HOME environmental variable for color db subdirectory
-	qui: dirfile, p(`"`: subinstr loc personal `"~"' `"`:environment HOME'"', all'brewcolors"')
+	// Set the rebuild parameter conditional on the replace argument
+	if `"`replace'"' != "" loc rebuild rebuild
+	
+	// Or make the local null
+	else loc rebuild
 	
 	// Remove tilde and replace with HOME environmental variable for color db subdirectory
-	qui: dirfile, p(`"`: subinstr loc personal `"~"' `"`:environment HOME'"', all'style"')
+	qui: dirfile, p(`"`: subinstr loc personal `"~"' `"`:environment HOME'"', all'brewcolors"') `rebuild'
+	
+	// Remove tilde and replace with HOME environmental variable for color db subdirectory
+	qui: dirfile, p(`"`: subinstr loc personal `"~"' `"`:environment HOME'"', all'style"') `rebuild'
 
 	// Check for file
 	cap confirm new file `"`c(sysdir_personal)'brewcolors/colordb.dta"'

--- a/brewscheme.pkg
+++ b/brewscheme.pkg
@@ -24,7 +24,7 @@ d KW: Color
 d
 d Requires: Stata version 13.1
 d
-d Distribution-Date: 20160404
+d Distribution-Date: 20160415
 d
 d Author: Billy Buchanan 
 d		  Data Scientist


### PR DESCRIPTION
Installation failed for user (reported in issue #45) due to the ado/personal directory not existing when brewcolordb attempted to build some of the local directories/files.  Now the command will test for the existence of the personal directory and will create the directory if it does not already exist before moving into the command execution.  
